### PR TITLE
added a doctrine dbal context for behat

### DIFF
--- a/Features/Context/DoctrineDbalContext.php
+++ b/Features/Context/DoctrineDbalContext.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CanalTP\SamCoreBundle\Features\Context;
+
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Symfony2Extension\Context\KernelDictionary;
+
+/**
+ * Defines application features from the specific context.
+ */
+class DoctrineDbalContext implements SnippetAcceptingContext
+{
+    use KernelDictionary;
+
+    public function truncateTables(array $tables)
+    {
+        $connection = $this->getContainer()->get('doctrine.dbal.default_connection');
+
+        foreach ($tables as $table) {
+            $connection->executeUpdate(
+                $connection->getDatabasePlatform()->getTruncateTableSQL($table, true)
+            );
+        }
+    }
+
+    /**
+     * @Given the following data in :dbTable exist:
+     */
+    public function theFollowingDataInExist($dbTable, TableNode $table)
+    {
+        $connection = $this->getContainer()->get('doctrine.dbal.default_connection');
+
+        foreach ($table->getHash() as $key => $row) {
+            $connection->insert($dbTable, $row);
+        }
+    }
+}


### PR DESCRIPTION
- Added a behat context to be able to inject data in database and truncate the data after each scenario

## How can you use it?

### Include the context in config/behat.yml
```yaml
default:
    ...

    suites:
        metrics:
            type: symfony_bundle
            bundle: CanalTPMetricsDashboardBundle
            contexts:
                - CanalTP\MetricsDashboardBundle\Features\Context\FeatureContext
                - CanalTP\SamCoreBundle\Features\Context\DoctrineDbalContext
```

### Inject data in database 
In your behat scenario

```
Scenario: Categories
        Given the following data in "metric.category" exist:
            | name        | customer_id |
            | Onglet 1    | 2           |
            | Onglet 2    | 2           |
        ...
```
This will inject data in **metric.category** table

### Truncate the data injected after each scenario
In your context
```php
class FeatureContext extends MinkContext
{
    /**
     * @AfterScenario
     */
    public function afterScenario(AfterScenarioScope $scope)
    {
        $environment = $scope->getEnvironment();
        $doctrineDbalContext = $environment->getContext('CanalTP\SamCoreBundle\Features\Context\DoctrineDbalContext');

        // Truncate all the tables you need to truncate
        $doctrineDbalContext->truncateTables([
            'metric.metrics_categories',
            'metric.metric',
            'metric.category',
            'metric.chart',
        ]);
    }
```
