### PR TITLE
Force the order of roles in user permissions list

### DIFF
--- a/Entity/ApplicationRepository.php
+++ b/Entity/ApplicationRepository.php
@@ -55,6 +55,7 @@ class ApplicationRepository extends EntityRepository
                 ->addSelect('r')
             ->leftJoin('a.roles', 'r', \Doctrine\ORM\Query\Expr\Join::WITH,  'r.isEditable = true')
             ->where('a.id = :id')
+            ->orderBy('r.id', 'ASC')
             ->setParameter('id', $appId);
 
         return $qb->getQuery()->getSingleResult();


### PR DESCRIPTION
Sometime, when user submit the form to update the permissions, it arrive that the user permissions list does not preserve order of the "role" column and does not updates the permissions who stay with the old order.

Example :

permissions \ roles | role 1 | role 2 
---|---|---
perm 1                   |      X   |           
perm 2                   |           |     X    

User saves the  changes and the page is reloaded

permissions \ roles | role 2  | role 1
---|---|---
perm 1                   |      X    |          
perm 2                   |            |     X   

Role 1 and 2 are inversed but permissions haven't been update 

If user saves again, the permissions will be changed with the involuntary assignation of new permissions and if user simply wants consult permissions, the information is wrong.

To correct it I propose to force the order of roles.