### PR TITLE
composer: add missing dependency for sam-monitoring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "php": ">=5.3.2",
         "canaltp/sam-ecore-application-manager-bundle": "~0.5",
         "canaltp/sam-ecore-user-manager-bundle": "^1.0",
-        "canaltp/sam-ecore-security-manager-bundle": "~0.5"
+        "canaltp/sam-ecore-security-manager-bundle": "~0.5",
+        "canaltp/sam-monitoring-bundle": "^1.0"
     },
     "autoload": {
         "psr-4": { "CanalTP\\SamCoreBundle\\": "" }


### PR DESCRIPTION
Hi,

Like I said in https://github.com/CanalTP/SamEcoreUserManagerBundle/pull/10, I'm currently trying to install a new NMM from scratch.

There is an other missing dependency that should be declared in the related bundle : 

```
[Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]
  The service "nmm.service_monitoring.database.psql" has a dependency on a non-existent parameter "sam.service_monitoring.database.pgsql.class".

grep -r sam.service_monitoring.database.pgsql.class vendor/canaltp/
vendor/canaltp/nmm-portal-bundle/Resources/config/services.yml:        class: "%sam.service_monitoring.database.pgsql.class%"
vendor/canaltp/sam-core-bundle/Resources/config/services.yml:        class: "%sam.service_monitoring.database.pgsql.class%"
```

It appears this dependency is duplicated in both sam-core-bundle and nmm-portal-bundle. I added it in this bundle but maybe it should be in the other or both. Tell me what you think about it.

Also the addition in AppKernel.php should be documented but I want to discuss about this before.

