### PR TITLE
composer: add missing dependency for knplabs/knp-menu-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "canaltp/sam-ecore-security-manager-bundle": "~0.5",
         "canaltp/sam-monitoring-bundle": "^1.0",
         "stof/doctrine-extensions-bundle": "~1.0",
-        "friendsofsymfony/jsrouting-bundle": "~1.0"
+        "friendsofsymfony/jsrouting-bundle": "~1.0",
+        "knplabs/knp-menu-bundle": "~1.1"
     },
     "autoload": {
         "psr-4": { "CanalTP\\SamCoreBundle\\": "" }


### PR DESCRIPTION
Hi,

See the [issue](https://github.com/CanalTP/SamCoreBundle/issues/29) for details :).