### PR TITLE
composer: add missing dependency for fos-js-rounting bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "canaltp/sam-ecore-user-manager-bundle": "^1.0",
         "canaltp/sam-ecore-security-manager-bundle": "~0.5",
         "canaltp/sam-monitoring-bundle": "^1.0",
-        "stof/doctrine-extensions-bundle": "~1.0"
+        "stof/doctrine-extensions-bundle": "~1.0",
+        "friendsofsymfony/jsrouting-bundle": "~1.0"
     },
     "autoload": {
         "psr-4": { "CanalTP\\SamCoreBundle\\": "" }


### PR DESCRIPTION
Hi,

There is a missing dependency with fos-js-routing.

The use of this bundle appears in both sam-core-bundle and nmm-portal-bundle.

```
grep -r fos_js vendor/canaltp/
vendor/canaltp/nmm-portal-bundle/Resources/views/config.js.html.twig:        sf_routes:                      '{{ path("fos_js_routing_js", {"callback": "fos.Router.setData"}) }}',
vendor/canaltp/sam-core-bundle/Resources/views/config.js.html.twig:        sf_routes:                                  '{{ path("fos_js_routing_js", {"callback": "fos.Router.setData"}) }}',
```