### PR TITLE
composer: add missing dependency for stof-doctrine-extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "canaltp/sam-ecore-application-manager-bundle": "~0.5",
         "canaltp/sam-ecore-user-manager-bundle": "^1.0",
         "canaltp/sam-ecore-security-manager-bundle": "~0.5",
-        "canaltp/sam-monitoring-bundle": "^1.0"
+        "canaltp/sam-monitoring-bundle": "^1.0",
+        "stof/doctrine-extensions-bundle": "~1.0"
     },
     "autoload": {
         "psr-4": { "CanalTP\\SamCoreBundle\\": "" }


### PR DESCRIPTION
Hi,

When I want to add fixtures in the database (for example by using sam:database:reset function), I get an error on some INSERT in the database : 

```
[info] Ugprading bundle 'CanalTPSamCoreBundle'...
[info] Done: bundle is now at version 009
[info] Ugprading bundle 'CanalTPNmmPortalBundle'...
[info] Done: bundle is now at version 002
> loading [1] CanalTP\NmmPortalBundle\DataFixtures\ORM\FixturesApplication
> loading [2] CanalTP\NmmPortalBundle\DataFixtures\ORM\FixturesCustomer

[Doctrine\DBAL\Exception\NotNullConstraintViolationException]
An exception occurred while executing 'INSERT INTO t_navitia_entity_nav (nav_id, nav_name, nav_name_canonical, nav_email, nav_email_canonical, nav_created, nav_updated) VALUES (?, ?, ?, ?, ?, ?, ?)' with params [1, "CanalTP", "ca
naltp", "nmm-ihm@canaltp.fr", "nmm-ihm@canaltp.fr", null, null]:
SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column "nav_created" violates not-null constraint

[Doctrine\DBAL\Driver\PDOException]
SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column "nav_created" violates not-null constraint

[PDOException]
SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column "nav_created" violates not-null constraint
```

This is due to missing bundles [gemdo](https://github.com/Atlantic18/DoctrineExtensions) and [stof](https://github.com/stof/StofDoctrineExtensionsBundle) as they're used to integrate some extensions which are currently used in sam-core-bundle (actually most are for the timestampable function): 

```
grep -r gedmo vendor/canaltp/
vendor/canaltp/nmm-portal-bundle/Resources/config/doctrine/NavitiaToken.orm.yml:            gedmo:
vendor/canaltp/nmm-portal-bundle/Resources/config/doctrine/NavitiaToken.orm.yml:            gedmo:
vendor/canaltp/nmm-portal-bundle/Resources/config/doctrine/NavitiaEntity.orm.yml:            gedmo:
vendor/canaltp/nmm-portal-bundle/Resources/config/doctrine/NavitiaEntity.orm.yml:            gedmo:
vendor/canaltp/nmm-portal-bundle/Resources/config/doctrine/CustomerApplication.orm.yml:            gedmo:
vendor/canaltp/nmm-portal-bundle/Resources/config/doctrine/CustomerApplication.orm.yml:            gedmo:
vendor/canaltp/nmm-portal-bundle/Resources/config/doctrine/Customer.orm.yml:            gedmo:
vendor/canaltp/nmm-portal-bundle/Resources/config/doctrine/Customer.orm.yml:            gedmo:
vendor/canaltp/sam-core-bundle/Resources/config/doctrine/CustomerApplication.orm.yml:            gedmo:
vendor/canaltp/sam-core-bundle/Resources/config/doctrine/CustomerApplication.orm.yml:            gedmo:
vendor/canaltp/sam-core-bundle/Resources/config/doctrine/Customer.orm.yml:            gedmo:
vendor/canaltp/sam-core-bundle/Resources/config/doctrine/Customer.orm.yml:            gedmo:
```

This PR add stof/doctrine-extensions-bundle which integrates gedmo.

The documentation should mention the AppKernel.php addition : 

```
...
new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
...
```

And its configuration in config.yml in order to make it work : 

```
stof_doctrine_extensions:
    default_locale:             "%locale%"
    orm:
        default:
            timestampable:      true
```

Thank you.