### PR TITLE
Symfony3 compatible

### DIFF
--- a/Doctrine/RoleListener.php
+++ b/Doctrine/RoleListener.php
@@ -3,21 +3,15 @@
 namespace CanalTP\SamCoreBundle\Doctrine;
 
 use CanalTP\SamCoreBundle\Entity\Role;
+use CanalTP\SamCoreBundle\Slugify;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 
 class RoleListener
 {
-    private $slugify;
-
-    public function __construct($slugify)
-    {
-        $this->slugify = $slugify;
-    }
-
     private function canonicalize(Role $role)
     {
-        $slug = $this->slugify->slugify($role->getName(), '_');
+        $slug = Slugify::format($role->getName(), '_');
 
         return 'ROLE_' . strtoupper($slug);
     }

--- a/Entity/Customer.php
+++ b/Entity/Customer.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use CanalTP\SamCoreBundle\Entity\Application;
+use CanalTP\SamCoreBundle\Slugify;
 
 /**
  * Customer
@@ -141,9 +142,7 @@ class Customer extends AbstractEntity implements CustomerInterface
      */
     protected function setNameCanonical($name)
     {
-        $slug = new \CanalTP\SamCoreBundle\Slugify();
-
-        $this->nameCanonical = $slug->slugify($name);
+        $this->nameCanonical = Slugify::format($name);
 
         return $this;
     }

--- a/Form/Type/CustomerType.php
+++ b/Form/Type/CustomerType.php
@@ -4,7 +4,7 @@ namespace CanalTP\SamCoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\File;
@@ -88,12 +88,7 @@ class CustomerType extends AbstractType
         );
     }
 
-    public function getName()
-    {
-        return 'customer';
-    }
-
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(

--- a/Menu/Builder.php
+++ b/Menu/Builder.php
@@ -4,11 +4,14 @@ namespace CanalTP\SamCoreBundle\Menu;
 
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use CanalTP\SamEcoreApplicationManagerBundle\Menu\BusinessMenuItemInterface;
 
-class Builder extends ContainerAware
+class Builder implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     public function mainMenu(FactoryInterface $factory, array $options)
     {
         $translator = $this->container->get('translator');

--- a/Slugify.php
+++ b/Slugify.php
@@ -4,7 +4,7 @@ namespace CanalTP\SamCoreBundle;
 
 class Slugify
 {
-    public function slugify($text, $separator = '-')
+    public static function format($text, $separator = '-')
     {
         // replace non letter or digits by -
         $text = preg_replace('~[^\\pL\d]+~u', $separator, $text);


### PR DESCRIPTION
fix 
```
+---+--------------------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| # | Usage                                                                                                                                      | Line | Comment                                                                       |
+---+--------------------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|   | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-core-bundle/Menu/Builder.php                                                                                                                         |
+---+--------------------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 1 | Extending deprecated class Symfony\Component\DependencyInjection\ContainerAware by class CanalTP\SamCoreBundle\Menu\Builder                | 10   | since version 2.8, to be removed in 3.0. Use the ContainerAwareTrait instead. |
+---+--------------------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|   | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-core-bundle/Form/Type/CustomerType.php                                                                                                               |
+---+--------------------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 2 | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                                      | 96   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead. |
| 3 | Overriding deprecated method CanalTP\SamCoreBundle\Form\Type\CustomerType->getName()                                                       | 91   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                   |
|   |                                                                                                                                            |      |  Use the fully-qualified class name of the type instead.                      |
| 4 | Overriding deprecated method CanalTP\SamCoreBundle\Form\Type\CustomerType->setDefaultOptions()                                             | 96   | since version 2.7, to be renamed in 3.0.                                      |
|   |                                                                                                                                            |      |  Use the method configureOptions instead. This method will be                 |
|   |                                                                                                                                            |      |  added to the FormTypeInterface with Symfony 3.0.                             |
+---+--------------------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|   | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-core-bundle/Slugify.php                                                                                                                              |
+---+--------------------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 5 | Using deprecated language feature PHP4 constructor                                                                                         | 7    | Since PHP 7.0, use __construct() instead.                                     |
+---+--------------------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|   | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-core-bundle/Features/Context/DoctrineDbalContext.php                                                                                                 |
+---+--------------------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 6 | Using deprecated interface Behat\Behat\Context\SnippetAcceptingContext by class CanalTP\SamCoreBundle\Features\Context\DoctrineDbalContext | 12   | will be removed in 4.0. Use --snippets-for CLI option instead                 |
+---+--------------------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
```

:exclamation: dependency to https://github.com/CanalTP/NmmPortalBundle/pull/53

Related to : https://jira.kisio.org/browse/GN-58
https://github.com/CanalTP/MatrixBundle/pull/68