### PR TITLE
Hotfix Version011.php

### DIFF
--- a/Migrations/pdo_pgsql/Version011.php
+++ b/Migrations/pdo_pgsql/Version011.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 /**
  * Adding created_at column in public.t_user_usr table
  */
-class Version001 extends AbstractMigration
+class Version011 extends AbstractMigration
 {
     const VERSION = '0.11.1';
 

--- a/Migrations/pdo_pgsql/Version011.php
+++ b/Migrations/pdo_pgsql/Version011.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
  */
 class Version001 extends AbstractMigration
 {
-    const VERSION = '0.1.1';
+    const VERSION = '0.11.1';
 
     public function getName()
     {


### PR DESCRIPTION
hotfix for :
```
./app/console claroline:migration:upgrade CanalTPSamCoreBundle --target=farthest --env=prod stderr: PHP Fatal error:  Cannot declare class CanalTP\SamCoreBundle\Migrations\pdo_pgsql\Version001, because the name is already in use in /srv/nmm-dev.canaltp.local/releases/20180517090151/vendor/canaltp/sam-core-bundle/Migrations/pdo_pgsql/Version011.php on line 42
```