### PR TITLE
No more bridge

### DIFF
--- a/Command/ResetDatabaseCommand.php
+++ b/Command/ResetDatabaseCommand.php
@@ -55,7 +55,7 @@ EOT
         $this->runCommand('doctrine:database:create', array(), $output);
 
         $applicationFinder = $this->getContainer()->get('canal_tp_sam.application.finder');
-        $applications = $applicationFinder->getBridgeApplicationBundles();
+        $applications = $applicationFinder->getApplicationBundles();
         // Create tables for each aplications
         foreach ($applications as $application) {
             $this->runCommand('claroline:migration:upgrade', array('bundle' => $application['bundle'], '--target' => 'farthest'), $output);


### PR DESCRIPTION
To resolve bug 
`
[Symfony\Component\Debug\Exception\UndefinedMethodException]                                                                      
  Attempted to call an undefined method named "getBridgeApplicationBundles" of class "CanalTP\SamEcoreApplicationManagerBundle\Ser  
  vices\ApplicationFinder".                                                                                                         
  Did you mean to call "getApplicationBundles"?
`

after trying in NMM :
`php app/console sam:database:reset --load-fixtures`
