### PR TITLE
GDPR fix weird user case if no creationDate

### DIFF
--- a/Services/GDPR/Factory.php
+++ b/Services/GDPR/Factory.php
@@ -28,6 +28,11 @@ class Factory
         $lastLoginDate = $user->getLastLogin();
         $creationDate = $user->getCreatedAt();
         $deletionDate = $user->getDeletionDate();
+        //if user has never been connected, deletion date isn't set and no creation date (DB fixture init)
+        if (!$lastLoginDate && !$deletionDate && !$creationDate) {
+            return $container->get('sam.gdpr.warning.notifier');
+        }
+
         //if user has never been connected, deletion date isn't set and creation date <= 5 month
         if (!$lastLoginDate && !$deletionDate && self::dateIsBeforeInactivityLimit($creationDate)) {
             return $container->get('sam.gdpr.warning.notifier');

--- a/Tests/Unit/Services/GDPR/FactoryTest.php
+++ b/Tests/Unit/Services/GDPR/FactoryTest.php
@@ -66,7 +66,8 @@ class FactoryTest extends GdprTestCase
             [$this->mockUser(14, $oneMonthLater, $sevenMonthAgo, $tenMonthAgo), Nothing::class],
             [$this->mockUser(15, $oneMonthAgo, $sevenMonthAgo, $fiveMonthAgo), Reset::class],
             [$this->mockUser(16, $oneMonthLater, $sevenMonthAgo, $oneMonthAgo), Reset::class],
-            [$this->mockUser(17, null, $oneMonthAgo, null), Nothing::class]
+            [$this->mockUser(17, null, null, null), Warning::class],
+            [$this->mockUser(18, null, $oneMonthAgo, null), Nothing::class]
         ];
     }
 

--- a/Tests/Unit/Services/GDPR/GdprTestCase.php
+++ b/Tests/Unit/Services/GDPR/GdprTestCase.php
@@ -27,9 +27,6 @@ class GdprTestCase extends UnitTestCase
 
     protected function mockUser($id, $deletionDate, $creationDate = null, $lastLoginDate = null, $isSuperAdmin = false, $mockMethods = [])
     {
-        if (is_null($creationDate)) {
-            $creationDate = new \DateTime();
-        }
         return $this->stubUser($id, $deletionDate, $creationDate, $lastLoginDate, $isSuperAdmin, $mockMethods, $this->mockCustomer());
     }
 
@@ -40,10 +37,7 @@ class GdprTestCase extends UnitTestCase
         $lastLoginDate = null,
         $isSuperAdmin = false,
         $mockMethods = []
-    ) {
-        if (is_null($creationDate)) {
-            $creationDate = new \DateTime();
-        }
+    ) {       
         return $this->stubUser($id, $deletionDate, $creationDate, $lastLoginDate, $isSuperAdmin, $mockMethods, null);
     }
 


### PR DESCRIPTION
It follows https://github.com/CanalTP/SamCoreBundle/pull/73

Fix weird user case if no creationDate (no more script crash)

*Test*
In your DB, search for a user with no creation_date, no deletion_date or edit one
Launch the script
`./app/console sam:gdpr -e prod -vv`

AT in BOT-2420 ([last comment](https://jira.kisio.org/browse/BOT-2420#comment-348304))